### PR TITLE
FISH-5975 Update sapphire and jetty libs repository url

### DIFF
--- a/releng/corundum-src/resources/jetty.properties
+++ b/releng/corundum-src/resources/jetty.properties
@@ -2,11 +2,12 @@
 
 rep.eclipse.jetty-9.4.7 = http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.7.v20170914
 rep.eclipse.jetty-9.4.8 = http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.8.v20171121
+rep.eclipse.jetty-9.4.44 = https://raw.githubusercontent.com/payara/ecosystem-eclipse-plugin/release-artifacts/repository/libs/jetty/9.4.44.v20210927
 
 rep.eclipse.jetty-oxygen.2 = ${rep.eclipse.jetty-9.4.7}
 rep.eclipse.jetty-photon = ${rep.eclipse.jetty-9.4.8}
-rep.eclipse.jetty-2020-03 = ${rep.eclipse.jetty-9.4.8}
-rep.eclipse.jetty-2020-06 = ${rep.eclipse.jetty-9.4.8}
-rep.eclipse.jetty-2020-09 = ${rep.eclipse.jetty-9.4.8}
+rep.eclipse.jetty-2020-03 = ${rep.eclipse.jetty-9.4.44}
+rep.eclipse.jetty-2020-06 = ${rep.eclipse.jetty-9.4.44}
+rep.eclipse.jetty-2020-09 = ${rep.eclipse.jetty-9.4.44}
 
 rep.eclipse.jetty-latest = ${rep.eclipse.jetty-2020-03}

--- a/releng/corundum-src/resources/sapphire.properties
+++ b/releng/corundum-src/resources/sapphire.properties
@@ -20,6 +20,6 @@ org.eclipse.sapphire.sdk.feature.group
 # Repositories
 
 rep.eclipse.sapphire-9.1 = http://download.eclipse.org/sapphire/9.1/repository/
-rep.eclipse.sapphire-9.1.1 = http://download.eclipse.org/sapphire/9.1.1/repository/
+rep.eclipse.sapphire-9.1.1 = https://raw.githubusercontent.com/payara/ecosystem-eclipse-plugin/release-artifacts/repository/libs/sapphire/9.1.1/
 
 rep.eclipse.sapphire-latest = ${rep.eclipse.sapphire-9.1.1}


### PR DESCRIPTION
This PR fixes the archived URLs of Payara Elipse tools dependencies.
Depends on https://github.com/payara/ecosystem-eclipse-plugin/pull/44