### PR TITLE
FISH-7326 Eclipse support Payara Server running on WSL

### DIFF
--- a/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/ui/wizards/MicroProjectWizardPage.java
+++ b/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/ui/wizards/MicroProjectWizardPage.java
@@ -60,7 +60,7 @@ public class MicroProjectWizardPage extends AbstractMavenWizardPage {
 		createUI(composite);
 		validate();
 		createAdvancedSettings(composite, new GridData(SWT.FILL, SWT.TOP, false, false, 3, 1));
-		resolverConfigurationComponent.setModifyListener(e -> validate());
+//		resolverConfigurationComponent.setModifyListener(e -> validate());
 		setControl(composite);
 	}
 

--- a/bundles/fish.payara.eclipse.tools.server/plugin.xml
+++ b/bundles/fish.payara.eclipse.tools.server/plugin.xml
@@ -686,7 +686,7 @@
             class="fish.payara.eclipse.tools.server.handlers.PayaraStateTester"
             id="fish.payara.eclipse.tools.server.PayaraStateTester"
             namespace="fish.payara.eclipse.tools.server"
-            properties="isRunning,isRemote"
+            properties="isRunning,isRemote,isWSLInstance"
             type="org.eclipse.wst.server.core.IServer">
         </propertyTester>
         <propertyTester
@@ -738,6 +738,16 @@
                     </test>
                 </and>
             </adapt>
+        </definition>
+        <definition id="fish.payara.eclipse.tools.server.isWSLInstance">
+            <and>
+                <count value="1"/>
+                <iterate ifEmpty="false">
+                    <and>
+                        <test property="fish.payara.eclipse.tools.server.isWSLInstance"/>
+                    </and>
+                </iterate>     
+            </and>
         </definition>
      
         <definition id="fish.payara.eclipse.tools.server.moreGlassfishSelected">
@@ -969,9 +979,12 @@
         >
             <enabledWhen>
                 <and>
-                    <not>    
-                        <reference definitionId="fish.payara.eclipse.tools.server.isRemoteGlassfish"/>
-                    </not>
+                    <or>
+                        <reference definitionId="fish.payara.eclipse.tools.server.isWSLInstance"/>
+                        <not>    
+                            <reference definitionId="fish.payara.eclipse.tools.server.isRemoteGlassfish"/>
+                        </not>
+                    </or>
                     <reference definitionId="fish.payara.eclipse.tools.server.oneGlassfishSelected"/>
                 </and>
             </enabledWhen>

--- a/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/PayaraServer.java
+++ b/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/PayaraServer.java
@@ -535,7 +535,7 @@ public final class PayaraServer extends ServerDelegate implements IURLProvider {
 	}
 
 	public String getDomainsFolder() {
-		if (!isRemote()) {
+		if (!isRemote() || isWSLInstance()) {
 			return new File(getDomainPath()).getParent();
 		}
 

--- a/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/PayaraServer.java
+++ b/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/PayaraServer.java
@@ -144,6 +144,7 @@ public final class PayaraServer extends ServerDelegate implements IURLProvider {
 	public static final String DEFAULT_HOT_DEPLOY = "false";
 	public static final String DEFAULT_TYPE = "";
 	public static final String DOCKER_TYPE = "Docker";
+	public static final String WSL_TYPE = "WSL";
 	protected static final String PROP_INSTANCE_TYPE = "instance.type";
 	protected static final String PROP_HOST_PATH = "host.path";
 	protected static final String PROP_CONTAINER_PATH = "container.path";
@@ -238,16 +239,14 @@ public final class PayaraServer extends ServerDelegate implements IURLProvider {
 
 	public boolean isRemote() {
 		return getServer().getServerType().supportsRemoteHosts()
-				&& (DOCKER_TYPE.equals(getInstanceType()) || !isLocalhost(getServer().getHost()));
+				&& (DOCKER_TYPE.equals(getInstanceType()) || WSL_TYPE.equals(getInstanceType()) || !isLocalhost(getServer().getHost()));
 	}
 
-	public String getDebugOptions(int debugPort) {
+    public String getDebugOptions(int debugPort) {
 		Version version = getVersion();
-
 		if (version.matches("[4")) {
 			return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + debugPort;
 		}
-
 		return "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=" + debugPort;
 	}
 
@@ -557,6 +556,10 @@ public final class PayaraServer extends ServerDelegate implements IURLProvider {
 
 	public boolean isDockerInstance() {
 		return DOCKER_TYPE.equals(getAttribute(PROP_INSTANCE_TYPE, (String) null));
+	}
+
+	public boolean isWSLInstance() {
+		return WSL_TYPE.equals(getAttribute(PROP_INSTANCE_TYPE, (String) null));
 	}
 
 	public String getInstanceType() {

--- a/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/deploying/PayaraServerBehaviour.java
+++ b/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/deploying/PayaraServerBehaviour.java
@@ -533,9 +533,10 @@ public final class PayaraServerBehaviour extends ServerBehaviourDelegate impleme
 
 		boolean isRemote = getPayaraServerDelegate().isRemote();
 		boolean isDockerInstance = getPayaraServerDelegate().isDockerInstance();
+		boolean isWSLInstance = getPayaraServerDelegate().isWSLInstance();
 		boolean isJarDeploy = getPayaraServerDelegate().getJarDeploy();
 
-		if ((!isRemote && !isJarDeploy) || isDockerInstance) {
+		if ((!isRemote && !isJarDeploy) || isDockerInstance || isWSLInstance) {
 			publishDeployedDirectory(kind, deltaKind, publishProperties, module, monitor);
 		} else {
 			publishJarFile(kind, deltaKind, publishProperties, module, monitor);
@@ -612,6 +613,7 @@ public final class PayaraServerBehaviour extends ServerBehaviourDelegate impleme
 			// the deployed apps
 			// so that the move operation Eclipse is doing sometimes can work.
 			boolean dockerInstance = getPayaraServerDelegate().isDockerInstance();
+			boolean wslInstance = getPayaraServerDelegate().isWSLInstance();
 			String hostPath = getPayaraServerDelegate().getHostPath();
 			String containerPath = getPayaraServerDelegate().getContainerPath();
 
@@ -680,7 +682,7 @@ public final class PayaraServerBehaviour extends ServerBehaviourDelegate impleme
 				CommandTarget command = null;
 				if (deltaKind == ADDED) {
 					command = new CommandDeploy(name, null, new File("" + path), contextRoot, properties, new File[0],
-							dockerInstance, hostPath, containerPath, hotDeploy);
+							dockerInstance, wslInstance, hostPath, containerPath, hotDeploy);
 				} else {
 					command = new CommandRedeploy(name, null, contextRoot, properties, new File[0], keepSession,
 							hotDeploy, metadataChanged, sourcesChanged);
@@ -724,6 +726,7 @@ public final class PayaraServerBehaviour extends ServerBehaviourDelegate impleme
 				String contextRoot = null;
 
 				boolean dockerInstance = getPayaraServerDelegate().isDockerInstance();
+				boolean wslInstance = getPayaraServerDelegate().isWSLInstance();
 				String hostPath = getPayaraServerDelegate().getHostPath();
 				String containerPath = getPayaraServerDelegate().getContainerPath();
 
@@ -738,7 +741,7 @@ public final class PayaraServerBehaviour extends ServerBehaviourDelegate impleme
 				try {
 					ServerAdmin.executeOn(getPayaraServerDelegate())
 							.command(new CommandDeploy(name, null, archivePath, contextRoot, getDeploymentProperties(),
-									new File[0], dockerInstance, hostPath, containerPath, hotDeploy))
+									new File[0], dockerInstance, wslInstance, hostPath, containerPath, hotDeploy))
 							.timeout(520).onNotCompleted(result -> {
 								logMessage("deploy is failing=" + result.getValue());
 								throw new IllegalStateException("deploy is failing=" + result.getValue());

--- a/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/handlers/PayaraStateTester.java
+++ b/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/handlers/PayaraStateTester.java
@@ -44,6 +44,14 @@ public class PayaraStateTester extends PropertyTester {
             }
         }
 
+        if (property.equals("isWSLInstance")) {
+            PayaraServer payaraServer = load(server, PayaraServer.class);
+
+            if (payaraServer != null) {
+                return payaraServer.isWSLInstance();
+            }
+        }
+
         return false;
     }
 

--- a/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/sdk/admin/CommandDeploy.java
+++ b/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/sdk/admin/CommandDeploy.java
@@ -69,7 +69,7 @@ public class CommandDeploy extends CommandTargetName {
 			throws PayaraIdeException {
 		try {
 			return ServerAdmin.<ResultString>exec(server, new CommandDeploy(null, null, application, null, null, null,
-					server.isDockerInstance(), server.getHostPath(), server.getContainerPath(), false), listener).get();
+					server.isDockerInstance(), server.isWSLInstance(), server.getHostPath(), server.getContainerPath(), false), listener).get();
 		} catch (InterruptedException | ExecutionException | CancellationException ie) {
 			throw new PayaraIdeException(ERROR_MESSAGE, ie);
 		}
@@ -100,6 +100,9 @@ public class CommandDeploy extends CommandTargetName {
 	/** Docker Instance. */
 	final boolean dockerInstance;
 
+	/** WSL Instance. */
+	final boolean wslInstance;
+
 	/** Host Path. */
 	final String hostPath;
 
@@ -122,10 +125,13 @@ public class CommandDeploy extends CommandTargetName {
 	 * @param properties     Deployment properties.
 	 * @param libraries      Not used in actual deploy command.
 	 * @param dockerInstance Docker Instance.
+	 * @param wslInstance    WSL Instance
+	 * @param hostPath
+	 * @param containerPath
 	 * @param hotDeploy      Hot Deploy.
 	 */
 	public CommandDeploy(String name, String target, File path, String contextRoot, Map<String, String> properties,
-			File[] libraries, final boolean dockerInstance, final String hostPath, final String containerPath,
+			File[] libraries, final boolean dockerInstance, final boolean wslInstance, final String hostPath, final String containerPath,
 			final boolean hotDeploy) {
 		super(COMMAND, name, target);
 
@@ -135,6 +141,7 @@ public class CommandDeploy extends CommandTargetName {
 		this.libraries = libraries;
 		this.dirDeploy = path.isDirectory();
 		this.dockerInstance = dockerInstance;
+		this.wslInstance = wslInstance;
 		this.hostPath = hostPath;
 		this.containerPath = containerPath;
 		this.hotDeploy = hotDeploy;

--- a/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/sdk/admin/RunnerHttpDeploy.java
+++ b/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/sdk/admin/RunnerHttpDeploy.java
@@ -137,6 +137,12 @@ public class RunnerHttpDeploy extends RunnerHttp {
 				throw new CommandException(CommandException.DOCKER_HOST_APPLICATION_PATH);
 			}
 		}
+		if (deploy.wslInstance) {
+			// Replace backslashes with forward slashes
+			path = path.replace("\\", "/");
+			// Add "mnt" prefix and drive letter
+			path = "/mnt/" + path.substring(0, 1).toLowerCase() + path.substring(2);
+		}
 		// Calculate StringBuilder initial length to avoid resizing
 		StringBuilder sb = new StringBuilder(DEFAULT_PARAM.length() + 1 + path.length() + 1 + FORCE_PARAM.length() + 1
 				+ force.length() + queryPropertiesLength(deploy.properties, PROPERTIES_PARAM)

--- a/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/sdk/admin/RunnerRestDeploy.java
+++ b/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/sdk/admin/RunnerRestDeploy.java
@@ -102,6 +102,12 @@ public class RunnerRestDeploy extends RunnerRest {
 				throw new CommandException(CommandException.DOCKER_HOST_APPLICATION_PATH);
 			}
 		}
+		if (command.wslInstance) {
+            // Replace backslashes with forward slashes
+            path = path.replace("\\", "/");
+            // Add "mnt" prefix and drive letter
+            path = "/mnt/" + path.substring(0, 1).toLowerCase() + path.substring(2);
+        }
 		OutputStreamWriter wr = new OutputStreamWriter(hconn.getOutputStream());
 		if (!command.dirDeploy) {
 			writeParam(wr, "path", path);

--- a/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/ui/wizards/NewPayaraServerWizardFragment.java
+++ b/bundles/fish.payara.eclipse.tools.server/src/fish/payara/eclipse/tools/server/ui/wizards/NewPayaraServerWizardFragment.java
@@ -111,7 +111,7 @@ public class NewPayaraServerWizardFragment extends WizardFragment {
 
 	private Combo instanceTypeCombo;
 
-	private String[] instanceTypes = { PayaraServer.DEFAULT_TYPE, PayaraServer.DOCKER_TYPE };
+	private String[] instanceTypes = { PayaraServer.DEFAULT_TYPE, PayaraServer.DOCKER_TYPE, PayaraServer.WSL_TYPE };
 
 	private Label hostLocationLabel;
 


### PR DESCRIPTION
This PR adds support for the Payara Server instance running on WSL. Usually, developers can register instances running on WSL as remote servers. However, with this PR, developers can take advantage of new features that allow them to auto-deploy on save action both static (.html) and dynamic (.java) applications to the Payara Server running on WSL.

To test this feature, start the server, set a password for the user, and enable the secure domain:
````
./asadmin start-domain
./asadmin change-admin-password
./asadmin enable-secure-admin
./asadmin restart-domain
````
![image](https://github.com/payara/ecosystem-eclipse-plugin/assets/15934072/40f229f1-cdb1-401e-9788-010ab722b95a)

Register the server as a Remote Server with WSL type:

![image](https://github.com/payara/ecosystem-eclipse-plugin/assets/15934072/eccb7eec-4a9e-4240-b309-96cb1075a6a5)

Fetch the IP address of WSL instance using the command `hostname -I` and enter it in the host name.
