### PR TITLE
FISH-8031 Add JDK Path field to Micro Project launch tab

### DIFF
--- a/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/MavenBuildTool.java
+++ b/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/MavenBuildTool.java
@@ -95,7 +95,7 @@ public class MavenBuildTool extends BuildTool {
 			commands.add("-DcontextRoot=" + contextPath);
 		}
 		if (microVersion != null && !microVersion.trim().isEmpty()) {
-			commands.add("-DpayaraVersion=" + microVersion);
+			commands.add("-Dpayara.micro.version=" + microVersion);
 		}
 		if (hotDeploy) {
 			commands.add("-DhotDeploy=true");

--- a/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/MicroConstants.java
+++ b/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/MicroConstants.java
@@ -22,12 +22,14 @@ public interface MicroConstants {
 	String ATTR_PORT = "port";
 
 	String JAVA_HOME_ENV_VAR = "JAVA_HOME";
+	String PAYARA_JAVA_HOME_SYS_PROP = "payara.java.home";
 
 	String ATTR_CONTEXT_PATH = "contextPath";
 	String ATTR_MICRO_VERSION = "microVersion";
 	String ATTR_BUILD_ARTIFACT = "buildArtifact";
 	String ATTR_DEBUG_PORT = "debugPort";
 	String ATTR_RELOAD_ARTIFACT = "reloadArtifact";
+	String ATTR_JDK_PATH = "jdkPath";
 
 	String WAR_BUILD_ARTIFACT = "War";
 	String EXPLODED_WAR_BUILD_ARTIFACT = "Exploded War";

--- a/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/ui/MicroProjectTab.java
+++ b/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/ui/MicroProjectTab.java
@@ -12,6 +12,7 @@ package fish.payara.eclipse.tools.micro.ui;
 import static fish.payara.eclipse.tools.micro.MicroConstants.ATTR_BUILD_ARTIFACT;
 import static fish.payara.eclipse.tools.micro.MicroConstants.ATTR_CONTEXT_PATH;
 import static fish.payara.eclipse.tools.micro.MicroConstants.ATTR_DEBUG_PORT;
+import static fish.payara.eclipse.tools.micro.MicroConstants.ATTR_JDK_PATH;
 import static fish.payara.eclipse.tools.micro.MicroConstants.ATTR_MICRO_VERSION;
 import static fish.payara.eclipse.tools.micro.MicroConstants.ATTR_RELOAD_ARTIFACT;
 import static fish.payara.eclipse.tools.micro.MicroConstants.AUTO_DEPLOY_ARTIFACT;
@@ -19,6 +20,7 @@ import static fish.payara.eclipse.tools.micro.MicroConstants.DEFAULT_DEBUG_PORT;
 import static fish.payara.eclipse.tools.micro.MicroConstants.EXPLODED_WAR_BUILD_ARTIFACT;
 import static fish.payara.eclipse.tools.micro.MicroConstants.HOT_DEPLOY_ARTIFACT;
 import static fish.payara.eclipse.tools.micro.MicroConstants.JAVA_HOME_ENV_VAR;
+import static fish.payara.eclipse.tools.micro.MicroConstants.PAYARA_JAVA_HOME_SYS_PROP;
 import static fish.payara.eclipse.tools.micro.MicroConstants.UBER_JAR_BUILD_ARTIFACT;
 import static fish.payara.eclipse.tools.micro.MicroConstants.WAR_BUILD_ARTIFACT;
 import static org.eclipse.core.externaltools.internal.IExternalToolConstants.ATTR_BUILD_SCOPE;
@@ -28,6 +30,7 @@ import static org.eclipse.core.externaltools.internal.IExternalToolConstants.ATT
 import static org.eclipse.debug.core.ILaunchManager.ATTR_ENVIRONMENT_VARIABLES;
 import static org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,6 +44,7 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -55,10 +59,14 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.m2e.core.ui.internal.MavenImages;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.DirectoryDialog;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Text;
 
@@ -67,7 +75,7 @@ import fish.payara.eclipse.tools.micro.ui.wizards.Messages;
 
 public class MicroProjectTab extends AbstractJavaMainTab {
 
-	private Text contextPathText, debugPortText;
+	private Text contextPathText, debugPortText, jdkPathText;
 	private Combo microVersionText, buildArtifactCombo, reloadArtifactCombo;
 
 	@Override
@@ -101,6 +109,26 @@ public class MicroProjectTab extends AbstractJavaMainTab {
 				new String[] { EMPTY_STRING, AUTO_DEPLOY_ARTIFACT, HOT_DEPLOY_ARTIFACT });
 		reloadArtifactCombo.addModifyListener(getDefaultListener());
 		reloadArtifactCombo.setToolTipText(Messages.reloadArtifactComponentTooltip);
+
+		group = SWTFactory.createGroup(mainComposite, Messages.jdkPathComponentLabel, 2, 1, GridData.FILL_HORIZONTAL);
+		jdkPathText = SWTFactory.createSingleText(group, 1);
+		jdkPathText.addModifyListener(getDefaultListener());
+		Button jdkBrowse = new Button(group, SWT.PUSH);
+		jdkBrowse.setText("Browse...");
+		jdkBrowse.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				DirectoryDialog dialog = new DirectoryDialog(jdkPathText.getShell());
+				String current = jdkPathText.getText().trim();
+				if (!current.isEmpty()) {
+					dialog.setFilterPath(current);
+				}
+				String selected = dialog.open();
+				if (selected != null && !selected.isEmpty()) {
+					jdkPathText.setText(selected);
+				}
+			}
+		});
 
 		setControl(mainComposite);
 	}
@@ -151,6 +179,14 @@ public class MicroProjectTab extends AbstractJavaMainTab {
 			setErrorMessage(ce.getStatus().getMessage());
 		}
 		reloadArtifactCombo.setText(reloadType);
+
+		String jdkPath = EMPTY_STRING;
+		try {
+			jdkPath = config.getAttribute(ATTR_JDK_PATH, jdkPath);
+		} catch (CoreException ce) {
+			setErrorMessage(ce.getStatus().getMessage());
+		}
+		jdkPathText.setText(jdkPath);
 	}
 
 	public Image getImage() {
@@ -221,11 +257,13 @@ public class MicroProjectTab extends AbstractJavaMainTab {
 				if (debugPort.isEmpty()) {
 					debugPort = String.valueOf(DEFAULT_DEBUG_PORT);
 				}
+				String jdkPath = jdkPathText.getText().trim();
 				config.setAttribute(ATTR_CONTEXT_PATH, contextPathText.getText());
 				config.setAttribute(ATTR_MICRO_VERSION, microVersionText.getText());
 				config.setAttribute(ATTR_BUILD_ARTIFACT, buildArtifactCombo.getText());
 				config.setAttribute(ATTR_DEBUG_PORT, debugPort);
 				config.setAttribute(ATTR_RELOAD_ARTIFACT, reloadArtifactCombo.getText());
+				config.setAttribute(ATTR_JDK_PATH, jdkPath);
 				config.setAttribute(ATTR_PROJECT_NAME, projectName);
 				config.setAttribute(ATTR_WORKING_DIRECTORY, project.getLocation().toOSString());
 				config.setAttribute(ATTR_BUILD_SCOPE, "${projects:" + project.getName() + "}");
@@ -233,13 +271,17 @@ public class MicroProjectTab extends AbstractJavaMainTab {
 				if (env.isEmpty()) {
 					config.setAttribute(ATTR_ENVIRONMENT_VARIABLES, env = new HashMap<>());
 				}
-				if (!env.containsKey(JAVA_HOME_ENV_VAR)) {
-					env.put(JAVA_HOME_ENV_VAR, getJavaHome(project));
-				}
+				
 				config.setAttribute(ATTR_LOCATION, buildTool.getExecutableHome());
 				boolean hotDeploy = HOT_DEPLOY_ARTIFACT.equals(reloadArtifactCombo.getText());
 				List<String> startCmd = buildTool.getStartCommand(contextPathText.getText(), microVersionText.getText(),
 						buildArtifactCombo.getText(), debugPort, hotDeploy);
+				if (!jdkPath.isEmpty()) {
+					startCmd.add("-D" + PAYARA_JAVA_HOME_SYS_PROP + "=\"" + resolveJavaExecutable(jdkPath) + "\"");
+					env.remove(JAVA_HOME_ENV_VAR);
+				} else if (!env.containsKey(JAVA_HOME_ENV_VAR)) {
+					env.put(JAVA_HOME_ENV_VAR, getJavaHome(project));
+				}
 				config.setAttribute(ATTR_TOOL_ARGUMENTS, String.join(" ", startCmd));
 			}
 		} catch (FileNotFoundException ex) {
@@ -253,6 +295,19 @@ public class MicroProjectTab extends AbstractJavaMainTab {
 		IJavaProject javaProject = JavaCore.create(project);
 		IVMInstall install = JavaRuntime.getVMInstall(javaProject);
 		return install.getInstallLocation().getAbsolutePath();
+	}
+
+	private static String resolveJavaExecutable(String jdkPath) {
+		File path = new File(jdkPath);
+		if (path.isFile()) {
+			return jdkPath;
+		}
+		boolean windows = Platform.OS_WIN32.equals(Platform.getOS());
+		String binary = windows ? "java.exe" : "java";
+		String base = path.getName().equalsIgnoreCase("bin")
+				? jdkPath
+				: jdkPath + File.separator + "bin";
+		return base + File.separator + binary;
 	}
 
 	@Override

--- a/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/ui/wizards/Messages.java
+++ b/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/ui/wizards/Messages.java
@@ -51,5 +51,6 @@ public class Messages extends org.eclipse.osgi.util.NLS {
 	public static String debugPortComponentLabel;
 	public static String reloadArtifactComponentLabel;
 	public static String reloadArtifactComponentTooltip;
+	public static String jdkPathComponentLabel;
 
 }

--- a/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/ui/wizards/Messages.properties
+++ b/bundles/fish.payara.eclipse.tools.micro/src/fish/payara/eclipse/tools/micro/ui/wizards/Messages.properties
@@ -33,3 +33,4 @@ buildArtifactComponentLabel=Build Artifact
 debugPortComponentLabel=Debug Port
 reloadArtifactComponentLabel=Reload Artifact on save
 reloadArtifactComponentTooltip=Reload Artifact feature is only available for Exploded War
+jdkPathComponentLabel=JDK Path


### PR DESCRIPTION
- Adds an optional "JDK Path" field with a Browse... button on the Micro
  Project tab.
- Accepts a JDK home, a bin directory, or a direct java executable,
- Also switches MavenBuildTool from the deprecated -DpayaraVersion to
  -Dpayara.micro.version to silence the payara-micro-maven-plugin
  deprecation warning.